### PR TITLE
update boolean discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This document aims to list a set of predefined device profiles to be used in home automation scenarios.
 
+# goals
+
+- provide a unambiguous representation of the state a device is in
+- provide a strict expectation for the user how a device behaves
+- allow flexibility in having required/optional/custom elements
+- provide hints for a UI, without specifying the UI implementation
+
 # Device structure
 
 Profiles are defined on a node level. Each node represents a certain capability a device posesses which provides state or functionality via its properties.
@@ -23,16 +30,18 @@ E.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 
 |id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
-|state|`boolean`|yes|yes|-|-|`true` = ON, `false` = OFF
+|state|`boolean`|yes|yes|-|off,on|format specifies labels for true/false
 |action|`enum`|yes|no|-|`toggle`| toggles state between true and false
 
 
 ### Comments:
-It can be argued that this is a simple binary switch and that it could be represented by an enum, however boolean is the basic definition of a binary switch and provides a uniform representation. 
-In general there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
+Since a boolean does not carry any context, the format property specifies the labels for the boolean values.
+The format is the same as an `enum` where `false` is the first and `true` is the second entry.
+Reasoning is that if the `enum` is an `array`, and `false` is often represented as 0 and `true` often as 1. Then those 0/1 values are the indices of the format `array` to ease implementations.
 
-We could opt for a binary state node with an enum, however this would then not properly convey the actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context.
+This format entry requires a change to the Homie protocol 
 
+The value could also be specified as an `enum` all together, but having a `boolean` provides a hint to a UI as to how to render the property (see the "goals" section").
 
 ## Dimmer
 `type`: "homie-device-profile/v1/type=dimmer"


### PR DESCRIPTION
previously I mentioned boolean should be replaced by enums since they do not carry any context. Changed my mind on that because the value it provides is that it is a hint to a UI on how to render the property. Hence this change.