### PR TITLE
leave 'settable' open

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This document aims to list a set of predefined device profiles to be used in hom
 
 Profiles are defined on a node level. Each node represents a certain capability a device posesses which provides state or functionality via its properties.
 
-e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
+E.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 - switch
 - dimmer
 - colorlight
@@ -21,7 +21,7 @@ e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |state|`boolean`|yes|yes|-|-|`true` = ON, `false` = OFF
 |action|`enum`|yes|no|-|`toggle`| toggles state between true and false
@@ -29,7 +29,7 @@ e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 
 ### Comments:
 It can be argued that this is a simple binary switch and that it could be represented by an enum, however boolean is the basic definition of a binary switch and provides a uniform representation. 
-In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
+In general there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
 
 We could opt for a binary state node with an enum, however this would then not properly convey the actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context.
 
@@ -41,7 +41,7 @@ We could opt for a binary state node with an enum, however this would then not p
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |brightness|`integer`|yes|yes|%|-|
 |action|`enum`|yes|no|-|`brighter,darker`| 
@@ -58,7 +58,7 @@ Another way could be a 'delta' property that simply receives +- values for adjus
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |color|`color`|yes|yes|-|`rgb/hsv`|
 |color-temperature|`integer`|yes|yes|Mired|`min:max`| fomat specifies min max values supported by the device

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This document aims to list a set of predefined device profiles to be used in hom
 
 # Device structure
 
-Profiles are defined on a node level. Each node represent a certain capability a device posesses which profide state or functionality via their properties.
+Profiles are defined on a node level. Each node represents a certain capability a device posesses which provides state or functionality via its properties.
 
-e.g. a dimmable RGB LED lighbuld could be represented via the following nodes:
+e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 - switch
 - dimmer
 - colorlight
@@ -24,19 +24,20 @@ e.g. a dimmable RGB LED lighbuld could be represented via the following nodes:
 |id|type|settable (defualt)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |state|`boolean`|yes|yes|-|-|`true` = ON, `false` = OFF
-|action|`enum`|yes|no|-|`toggle`| 
+|action|`enum`|yes|no|-|`toggle`| toggles state between true and false
 
 
 ### Comments:
 It can be argued that this is a simple binary switch and that it could be represented by an enum, however boolean is the basic definition of a binary switch and provides a uniform representation. 
-In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level....
-We could opt for a binary state node with an enum, however this would then not properly convey they actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context....
+In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
+
+We could opt for a binary state node with an enum, however this would then not properly convey the actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context.
 
 
 ## Dimmer
 `type`: "homie-device-profile/v1/type=dimmer"
 
-*Example usages*: Dimm capability of a dimmable light.
+*Example usages*: Dimmable light.
 
 ### Properties
 
@@ -46,14 +47,14 @@ We could opt for a binary state node with an enum, however this would then not p
 |action|`enum`|yes|no|-|`brighter,darker`| 
 
 ### Comments:
-The brighter and darker actions are problematic in so far as that we would need to define the delta adjustment value. But depending on the devices practical values could be difficult to align... 
-An argument could be made to completly remove this feature all together but it has proved to be rather practical in home automation scenarios...
-Another way could be a 'delta' property that simply receives +- values for adjustments... 
+The brighter and darker actions are problematic in so far as that we would need to define the delta adjustment value. But depending on the devices practical values could be difficult to align.
+An argument could be made to completly remove this feature all together but it has proved to be rather practical in home automation scenarios.
+Another way could be a 'delta' property that simply receives +- values for adjustments.
 
 ## Colorlight
 `type`: "homie-device-profile/v1/type=colorlight"
 
-*Example usages*: Dimm capability of a dimmable light.
+*Example usages*: Color control for a lightbulb or LED strip.
 
 ### Properties
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ The switch has no effect on the dimmer state, nor the dimmer state on the switch
 
 # Capability descriptions
 
+Considerations:
+
+- The model is not necessarily the same as the UI. An example of this is a dimmable light; `brightness` is typically 0-100%. But 0 would be ambiguous for the user, because powered on, at level 0% still means it is off. So the `brightness` model should be 1-100% to make it unambiguous. It is important to note that the model is the STATE representation, not the UI representation. A UI is still free in how it renders the state; a single slider 0-100, a switch and 1-100, or a switch and 0-100.
+- Not every device is controllable. Hence the `settable` property should generally be `yes/no` at the discretion of the implementor.
+
 ## Switch
 `type`: "homie-capability-profile/v1/type=switch"
 
@@ -84,7 +89,7 @@ The switch has no effect on the dimmer state, nor the dimmer state on the switch
 
 |id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
-|state|`boolean`|yes|yes|-|off,on|format specifies labels for false/true
+|state|`boolean`|yes/no|yes|-|off,on|format specifies labels for false/true
 |action|`enum`|yes|no|-|`toggle`| toggles state between true and false
 
 
@@ -106,12 +111,10 @@ The value could also be specified as an `enum` all together, but having a `boole
 
 |id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
-|brightness|`integer`|yes|yes|%|`1:100`|0 is not allowed since it would be ambiguous
+|brightness|`integer`|yes/no|yes|%|`1:100`|0 is not allowed since it would be ambiguous
 |action|`enum`|yes|no|-|`brighter,darker`| 
 
 ### Comments:
-`brightness` is restricted from 1 to 100%, 0 would be ambiguous. It is important to note that this is the STATE representation, not the UI representation. A UI is still free in how it renders the state; a single slider 0-100, a switch and 1-100, or a switch and 0-100.
-
 The brighter and darker actions are problematic in so far as that we would need to define the delta adjustment value. But depending on the devices practical values could be difficult to align.
 An argument could be made to completly remove this feature all together but it has proved to be rather practical in home automation scenarios.
 Another way could be a 'delta' property that simply receives +- values for adjustments.
@@ -125,5 +128,5 @@ Another way could be a 'delta' property that simply receives +- values for adjus
 
 |id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
-|color|`color`|yes|yes|-|`rgb/hsv`|
+|color|`color`|yes/no|yes|-|`rgb/hsv`|
 |color-temperature|`integer`|yes|yes|Mired|`min:max`| fomat specifies min max values supported by the device


### PR DESCRIPTION
Not every device is controllable. Hence the `settable` property should generally be `yes/no` at the discretion of the implementor.