### PR TITLE
proposal for queryable topic structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This document aims to list a set of predefined device profiles to be used in hom
 
 Profiles are defined on a node level. Each node represents a certain capability a device posesses which provides state or functionality via its properties.
 
-e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
+E.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 - switch
 - dimmer
 - colorlight
@@ -21,7 +21,7 @@ e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |state|`boolean`|yes|yes|-|-|`true` = ON, `false` = OFF
 |action|`enum`|yes|no|-|`toggle`| toggles state between true and false
@@ -29,7 +29,7 @@ e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 
 ### Comments:
 It can be argued that this is a simple binary switch and that it could be represented by an enum, however boolean is the basic definition of a binary switch and provides a uniform representation. 
-In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
+In general there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
 
 We could opt for a binary state node with an enum, however this would then not properly convey the actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context.
 
@@ -41,7 +41,7 @@ We could opt for a binary state node with an enum, however this would then not p
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |brightness|`integer`|yes|yes|%|-|
 |action|`enum`|yes|no|-|`brighter,darker`| 
@@ -58,7 +58,7 @@ Another way could be a 'delta' property that simply receives +- values for adjus
 
 ### Properties
 
-|id|type|settable (defualt)|retained|unit|format|comment
+|id|type|settable (default)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |color|`color`|yes|yes|-|`rgb/hsv`|
 |color-temperature|`integer`|yes|yes|Mired|`min:max`| fomat specifies min max values supported by the device

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This document aims to list a set of predefined device profiles to be used in hom
 
 # Device structure
 
-Profiles are defined on a node level. Each node represent a certain capability a device posesses which profide state or functionality via their properties.
+Profiles are defined on a node level. Each node represents a certain capability a device posesses which provides state or functionality via its properties.
 
-e.g. a dimmable RGB LED lighbuld could be represented via the following nodes:
+e.g. a dimmable RGB LED lighbulb could be represented via the following nodes:
 - switch
 - dimmer
 - colorlight
@@ -24,19 +24,20 @@ e.g. a dimmable RGB LED lighbuld could be represented via the following nodes:
 |id|type|settable (defualt)|retained|unit|format|comment
 |-|-|-|-|-|-|-|
 |state|`boolean`|yes|yes|-|-|`true` = ON, `false` = OFF
-|action|`enum`|yes|no|-|`toggle`| 
+|action|`enum`|yes|no|-|`toggle`| toggles state between true and false
 
 
 ### Comments:
 It can be argued that this is a simple binary switch and that it could be represented by an enum, however boolean is the basic definition of a binary switch and provides a uniform representation. 
-In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level....
-We could opt for a binary state node with an enum, however this would then not properly convey they actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context....
+In generel there are a lot of devies with binary state representations, e.g. battery low: true/false, light: on/off, contact/door: open/closed, sensor: motion/nomotion, tilt-sensor: tilted/level,...
+
+We could opt for a binary state node with an enum, however this would then not properly convey the actual context for the capbility, a switch is not the same as a door-contact sensor, even though they both have essentially 2 states - but the goal should also be to provide context.
 
 
 ## Dimmer
 `type`: "homie-device-profile/v1/type=dimmer"
 
-*Example usages*: Dimm capability of a dimmable light.
+*Example usages*: Dimmable light.
 
 ### Properties
 
@@ -46,14 +47,14 @@ We could opt for a binary state node with an enum, however this would then not p
 |action|`enum`|yes|no|-|`brighter,darker`| 
 
 ### Comments:
-The brighter and darker actions are problematic in so far as that we would need to define the delta adjustment value. But depending on the devices practical values could be difficult to align... 
-An argument could be made to completly remove this feature all together but it has proved to be rather practical in home automation scenarios...
-Another way could be a 'delta' property that simply receives +- values for adjustments... 
+The brighter and darker actions are problematic in so far as that we would need to define the delta adjustment value. But depending on the devices practical values could be difficult to align.
+An argument could be made to completly remove this feature all together but it has proved to be rather practical in home automation scenarios.
+Another way could be a 'delta' property that simply receives +- values for adjustments.
 
 ## Colorlight
 `type`: "homie-device-profile/v1/type=colorlight"
 
-*Example usages*: Dimm capability of a dimmable light.
+*Example usages*: Color control for a lightbulb or LED strip.
 
 ### Properties
 

--- a/topic-structure.md
+++ b/topic-structure.md
@@ -1,0 +1,135 @@
+# Profile topic structure
+
+**Note 1**: this proposal is not tied to the Homie v5-draft proposal. It will equally work with Homie 4.
+
+**Note 2**: the device and capability profiles in this document are just examples and no official references of how those devices and capabilities would/should be implemented.
+
+## Profile types
+
+There are 2 profile types;
+
+- Capability profiles (implemented on Homie Node level), eg.
+    - `power-switch`
+    - `dimmer`
+- Device profiles (implemented on Homie Device level), eg.
+    - `binary-light`, having;
+        - `power` node, being a `power-switch` capability
+    - `dimmable-light`, having;
+        - `power` node, being a `power-switch` capability
+        - `brightness` node, being a `dimmer` capability
+
+For the remainder of this document we'll assume the `binary-light` to have a `power-switch` capability (called `power`). And the `dimmable-light` to have both the `power-switch` (called `power`) as well as the `dimmer` capability (called `brightness`).
+
+Each Homie device can implement multiple device profiles, even of the same type. Each device-type can have multiple capability profiles, even of the same type.
+
+If multiple instances of devices and/or capabilities are supported on a device, then each type MUST exist only in a single version. So if a device has 2 `binary-light` types, then they both MUST be of the same version.
+
+Capabilities on a single Homie device, but on different device profiles MAY implement different versions of a capability. So if a single Homie device has 1 `binary-light` profile and 1 `dimmable-light` profile. Then the `binary-light` could have `power-switch` v1.0 and the `dimmable-light` could have `power-switch` v1.2. As long as the capability profiles within a single device profile are all the same version.
+
+## Topic structures
+
+Since a controller should be able to query the MQTT server for a specific device-profile
+and/or capability profile, the required information must be in the topic structure
+such that the proper mqtt subscription only returns the elements the controller
+is interested in.
+
+
+## Device profile versions
+
+Profile information is stored under the `$profile` key. Because the query capability must be able to return compatible devices, the full-key should include the MAJOR version component, and a MINOR version. The value is the number of instances the device has of this profile.
+
+A device implementing the profile with ID `binary-light` version `1.2` posts this topic:
+```
+homie/device-id/$profile/binary-light/1/2 → "1"
+```
+
+| element | meaning |
+|---------|---------|
+| `homie` | The Homie base-topic |
+| `device-id` | The Homie ID of the Homie device |
+| `$profile` | The topic indicating supported device profiles |
+| `binary-light/1/2` | The device profile `binary-light` is supported at version `1.2` |
+| `"1"` | The device implements 1 instance of the `power-switch` capability |
+
+## Querying for device types
+
+A controller that wishes to control `binary-light` instances and has an implementation compatible with version 1.2. Would execute the following steps to control the devices;
+
+1. subscribe to `homie/+/$profile/binary-light/1/+`, this will return all Homie devices implementing a `binary-light` of version `1.x`.
+2. any version found that is > `1.2` should be controlled as if it was `1.2`.
+3. any version found <= `1.2` should be controlled at its specfied version.
+
+## Multiple devices of the same type
+
+If a device implements multiple of the same device profiles, then the versioned topic tells the controller how many there are.
+
+Assuming a Zwave device with a double relay, controlling 2 lights, exposed as device type `binary-light` v1.0. Then it publishes;
+```
+homie/device-id/$profile/binary-light/1/0 → "2"
+```
+The capabilities will get a numbered post-fix to be able to identify them. So if both relais are enabled the following values will be posted;
+```
+homie/device-id/power-1/state-1 → "true"
+homie/device-id/power-2/state-1 → "true"
+```
+
+| element | meaning |
+|---------|---------|
+| `homie` | The Homie base-topic |
+| `device-id` | The Homie ID of the Homie device |
+| `power-1` / `power-2` | The Homie Node ID, the name is dictated in the `binary-light` device-profile description, and it has 2 instances |
+| `state-1` | the Homie property `state` is the property carrying the state of the relay. The ID is defined in either the device profile, or the capability profile (see below). This example has only 1 instance. |
+| `"true"` | The value of the Homie property (in this case a boolean). |
+
+(in this case the Homie property `state` is the property carrying the state of the relay)
+
+The numbered postfix MUST be added, even if there is only 1 instance.
+
+## Capability profile version
+
+This is stored similarly to the device profile, but now on the Homie node level.
+So a device implementing a single `power-switch` capability of version 1.1 would post;
+```
+homie/device-id/power-1/$profile/power-switch/1/1 → "1"
+```
+
+| element | meaning |
+|---------|---------|
+| `homie` | The Homie base-topic |
+| `device-id` | The Homie ID of the Homie device |
+| `power-1` | the Homie ID of the node. In this case it looks like the device profile specified a capability named `power`, and this is instance `1` of that capability. |
+| `$profile` | The topic indicating supported capability profiles |
+| `power-switch/1/1` | The capability profile `power-switch` is supported in version `1.1` |
+| `"1"` | The capability implements 1 instance of the `power-switch` capability |
+
+
+## Multiple capabilities of the same type
+
+This also works similar to multiple device profiles. Assume a wall-mounted touch-panel used to control lights. It is a single panel, but has 4 touch areas to control 4 devices. (this example uses 4 switches in 1 capability, where it could also have been 4 devices with each 1 switch obviously)
+
+It announces its capabilities like this:
+```
+homie/device-id/switch-1/$profile/wall-switch/1/2 → "4"
+```
+
+It would have these Homie properties, with example values;
+```
+homie/device-id/switch-1/button-1 → "double-click"
+homie/device-id/switch-1/button-2 → "click"
+homie/device-id/switch-1/button-3 → "hold"
+homie/device-id/switch-1/button-4 → "release"
+```
+
+## Querying for capability types
+
+If we change the examples to a device profile called `light`, that has;
+
+- a `power-switch` capability called `power` (required)
+- an optional `dimmer` capability called `brightness` 
+
+And in this setting a controller wishes to find all dimmable lights, then it would;
+
+1. subscribe to `homie/+/$profile/light/1/+`, this will return all Homie devices implementing a `light` of version `1.x`.
+2. subscribe to `homie/+/+/$profile/dimmer/1/+`, this will return all capabilities implementing a `dimmer` of version `1.x`.
+3. The cross-section of the 2 sets returns will be the dimmable lights. And equally so the first set (lights), with the 2nd set (dimmers) substracted will be the set of non-dimmable lights.
+


### PR DESCRIPTION
This proposes a structure that makes the implemented device profiles and capabilities queryable by mqtt-topic-subscription

direct link to the [rendered doc](https://github.com/homieiot/homie5-device-profiles/blob/topics/topic-structure.md)